### PR TITLE
public React site is successfully mounted and routed to Rails app

### DIFF
--- a/app/controllers/public_site_controller.rb
+++ b/app/controllers/public_site_controller.rb
@@ -1,0 +1,5 @@
+class PublicSiteController < ApplicationController
+  def index
+    render :'public_site/index'
+  end
+end

--- a/app/javascript/packs/index.js
+++ b/app/javascript/packs/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PublicSite from '../react/src/PublicSite';
+
+document.addEventListener('DOMContentLoaded', () => {
+  let publicSite = document.getElementById('public-site')
+  if(publicSite) {
+    ReactDOM.render(<PublicSite />, publicSite);
+  }
+})

--- a/app/javascript/react/src/PublicSite.js
+++ b/app/javascript/react/src/PublicSite.js
@@ -2,7 +2,10 @@ import React from 'react';
 
 const App = props => {
   return(
-    <h1>Hello World</h1>
+    <div>
+      <h1>Hello World</h1>
+      <h2>This is Tunsure</h2>
+    </div>
   )
 }
 

--- a/app/javascript/react/test/AppTest.js
+++ b/app/javascript/react/test/AppTest.js
@@ -1,13 +1,13 @@
-import App from '../src/App';
+import PublicSite from '../src/PublicSite';
 import React from 'react'
 import { mount } from 'enzyme';
 import jasmineEnzyme from 'jasmine-enzyme';
 
-describe('A test for App', () => {
+describe('A test for PublicSite', () => {
   let wrapper;
 
   beforeEach(() => {
-    wrapper = mount(<App />)
+    wrapper = mount(<PublicSite />)
   })
 
   it('should pass', () => {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,14 +1,22 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>SoftwareDevelopment</title>
-    <%= csrf_meta_tags %>
+    <title>Tunsure</title>
+    </title><meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <%= stylesheet_link_tag    'application', media: 'all' %>
-    <%= javascript_include_tag 'application' %>
+    <title><%= content_for?(:title) ? yield(:title) : "tunsure" %></title>
+
+    <%= javascript_pack_tag 'index.js' %>
+
+    <%= csrf_meta_tags %>
   </head>
 
   <body>
     <%= yield %>
+
+    <%= javascript_include_tag "vendor/modernizr" %>
+    <%= javascript_include_tag 'application' %>
+    <%= stylesheet_link_tag  'application' %>
   </body>
 </html>

--- a/app/views/public_site/index.html.erb
+++ b/app/views/public_site/index.html.erb
@@ -1,0 +1,3 @@
+<div id="public-site">
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root 'public_site#index'
+  get '*path', to: 'public_site#index'
 end


### PR DESCRIPTION
Most basic configuration for React/Rails app. The redirect for the root path will probably stay as the public site for now until the app gets more complex.  The `get '*path', to: 'public_site#index'` 'catch-all' in `routes.rb` will most likely have to change once there are two single-page apps served up by the Rails server.